### PR TITLE
Use 'command -v' instead of 'which'

### DIFF
--- a/calcfetch
+++ b/calcfetch
@@ -10,7 +10,7 @@ shell=${SHELL##*/}
 
 ## PACKAGE MANAGER AND PACKAGES DETECTION
 
-manager=$(command which nix-env yum dnf rpm xbps-query apt zypper pacman apk cpm)
+manager=$(command -v nix-env yum dnf rpm xbps-query apt zypper pacman apk cpm)
 manager=${manager##*/}
 case $manager in
     cpm) packages="$(cpm C)";;


### PR DESCRIPTION
Use shell built-in `command -v` to eliminate the need for `which` external command.