### PR TITLE
Redirected output of pkgmgr search

### DIFF
--- a/calcfetch
+++ b/calcfetch
@@ -24,7 +24,7 @@ esac
 
 ## PACKAGE MANAGER AND PACKAGES DETECTION
 
-manager=$(which nix-env yum dnf rpm xbps-query apt brew port zypper pacman apk cpm)
+manager=$(which nix-env yum dnf rpm xbps-query apt brew port zypper pacman apk cpm)>/dev/null 2>&1
 manager=${manager##*/}
 case $manager in
 	cpm) packages="$(cpm C)";;


### PR DESCRIPTION
Redirected `stderr` and `stdout` of the command to search for package managers to `/dev/null`.

Original fetch output:

![shot_0907125830](https://user-images.githubusercontent.com/33443763/92414861-fcb66400-f10a-11ea-985d-37abb4024ae4.png)

Edited fetch output:

![shot_0907125919](https://user-images.githubusercontent.com/33443763/92414869-09d35300-f10b-11ea-9b52-082a68d3e5fe.png)
