### PR TITLE
Adding Solus as the tested, working OSes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ calcfetch
 - Unlike neofetch, it uses almost no resources
 - Portable
 - POSIX compliant
-- Tested on Pop!_OS, NixOS, Ubuntu, Alpine, Debian, macOS 10, Arch, Manjaro, Bedrock, Gentoo, Kiss, EndeavorOS, and Android
+- Tested on Pop!_OS, NixOS, Ubuntu, Alpine, Debian, macOS 10, Arch, Manjaro, Bedrock, Gentoo, Kiss, EndeavorOS, Solus, and Android
 
 ### OSes supported:
 - Debian/Ubuntu based Linux
@@ -44,6 +44,7 @@ calcfetch
 - KISS Linux
 - Void Linux
 - Gentoo Linux
+- Solus Linux
 - macOS 10.x
 
 ### Know issues:

--- a/calcfetch
+++ b/calcfetch
@@ -24,7 +24,7 @@ esac
 
 ## PACKAGE MANAGER AND PACKAGES DETECTION
 
-manager=$(which nix-env yum dnf rpm apt brew port zypper pacman xbps-query pkg emerge apk kiss brl cpm 2>/dev/null)
+manager=$(which nix-env yum dnf rpm apt brew port zypper pacman xbps-query pkg emerge apk kiss brl cpm eopkg 2>/dev/null)
 manager=${manager##*/}
 case $manager in
 	cpm) packages="$(cpm C)";;
@@ -42,6 +42,7 @@ case $manager in
 	nix-env) packages="$(nix-store -q --requisites /run/current-system/sw | wc -l)";;
 	apk) packages="$(apk list --installed | wc -l)";;
 	brl) packages="$(brl list | wc -l)";;
+	eopkg) packages="$(eopkg li | wc -l)";;
 	*) packages="idk"
 esac
 


### PR DESCRIPTION
```
❯ gh repo clone ThatOneCalculator/CalcFetch
Clonage dans 'CalcFetch'...
remote: Enumerating objects: 102, done.
remote: Counting objects: 100% (102/102), done.
remote: Compressing objects: 100% (102/102), done.
remote: Total 289 (delta 46), reused 1 (delta 0), pack-reused 187
Réception d'objets: 100% (289/289), 84.38 Kio | 929.00 Kio/s, fait.
Résolution des deltas: 100% (142/142), fait.

~ 
❯ cd CalcFetch

CalcFetch on  master 
❯ sudo install -m755 calcfetch /bin/calcfetch

CalcFetch on  master 
❯ cd ..

~ 
❯ sudo rm -r CalcFetch/

~ 
❯ calcfetch 

      ___     pm@vix 
     (.. \      Solus 4.1 Fortitude
     (<> |      5.6.19-158.current
    //  \ \     15099/32043 MB (47%)
   ( |  | /|    idk ()
  _/\ __)/_)    3 hours, 26 mins
  \/-____\/     █████████████████████

~ 
❯ 
```

I can confirm, working perfectly on Solus, as it should.